### PR TITLE
Faster identification of market indeces via pandas.Series.groupby

### DIFF
--- a/pyblp/construction.py
+++ b/pyblp/construction.py
@@ -7,7 +7,7 @@ import numpy as np
 from . import options
 from .configurations.formulation import Formulation
 from .configurations.integration import Integration
-from .utilities.basics import Array, Groups, RecArray, extract_matrix, interact_ids, structure_matrices
+from .utilities.basics import Array, Groups, RecArray, extract_matrix, interact_ids, structure_matrices, get_indices
 
 
 def build_id_data(T: int, J: int, F: int) -> RecArray:
@@ -354,7 +354,7 @@ def build_differentiation_instruments(
         raise ValueError("The firm_ids field of product_data must be one-dimensional.")
 
     # identify markets
-    market_indices = {t: np.flatnonzero(market_ids.flat == t) for t in np.unique(market_ids)}
+    market_indices = get_indices(market_ids)
 
     # build the matrix and count its dimensions
     X = build_matrix(formulation, product_data)

--- a/pyblp/economies/economy.py
+++ b/pyblp/economies/economy.py
@@ -73,8 +73,8 @@ class Economy(Container, StringRepresentation):
         self.H = self.unique_nesting_ids.size
 
         # identify market indices
-        self._product_market_indices: Dict[Hashable, Array] = get_indices(self.products.market_ids)
-        self._agent_market_indices: Dict[Hashable, Array] = get_indices(self.agents.market_ids)
+        self._product_market_indices = get_indices(self.products.market_ids)
+        self._agent_market_indices = get_indices(self.agents.market_ids)
 
         # identify the largest number of products and agents in a market
         self._max_J = max(i.size for i in self._product_market_indices.values())

--- a/pyblp/economies/economy.py
+++ b/pyblp/economies/economy.py
@@ -4,6 +4,7 @@ import abc
 import functools
 from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence
 
+import pandas as pd
 import numpy as np
 
 from .. import options
@@ -73,11 +74,10 @@ class Economy(Container, StringRepresentation):
         self.H = self.unique_nesting_ids.size
 
         # identify market indices
-        self._product_market_indices: Dict[Hashable, Array] = {}
-        self._agent_market_indices: Dict[Hashable, Array] = {}
-        for t in self.unique_market_ids:
-            self._product_market_indices[t] = np.flatnonzero(self.products.market_ids == t)
-            self._agent_market_indices[t] = np.flatnonzero(self.agents.market_ids == t)
+        s = pd.Series(self.products.market_ids.flatten())
+        self._product_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).groups.items()}
+        s = pd.Series(self.agents.market_ids.flatten())
+        self._agent_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).groups.items()}
 
         # identify the largest number of products and agents in a market
         self._max_J = max(i.size for i in self._product_market_indices.values())

--- a/pyblp/economies/economy.py
+++ b/pyblp/economies/economy.py
@@ -4,14 +4,13 @@ import abc
 import functools
 from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence
 
-import pandas as pd
 import numpy as np
 
 from .. import options
 from ..configurations.formulation import Formulation
 from ..primitives import Container
 from ..utilities.algebra import precisely_identify_collinearity, precisely_identify_psd
-from ..utilities.basics import Array, RecArray, StringRepresentation, format_table
+from ..utilities.basics import Array, RecArray, StringRepresentation, format_table, get_indices
 
 
 class Economy(Container, StringRepresentation):
@@ -54,8 +53,8 @@ class Economy(Container, StringRepresentation):
         self.agent_formulation = agent_formulation
 
         # identify unique markets and nests
-        self.unique_market_ids = np.unique(self.products.market_ids).flatten()
-        self.unique_firm_ids = np.unique(self.products.firm_ids).flatten()
+        self.unique_market_ids = np.unique(self.products.market_ids.flatten())
+        self.unique_firm_ids = np.unique(self.products.firm_ids.flatten())
         self.unique_nesting_ids = np.unique(self.products.nesting_ids).flatten()
 
         # count dimensions
@@ -74,10 +73,8 @@ class Economy(Container, StringRepresentation):
         self.H = self.unique_nesting_ids.size
 
         # identify market indices
-        s = pd.Series(self.products.market_ids.flatten())
-        self._product_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).indices.items()}
-        s = pd.Series(self.agents.market_ids.flatten())
-        self._agent_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).indices.items()}
+        self._product_market_indices: Dict[Hashable, Array] = get_indices(self.products.market_ids)
+        self._agent_market_indices: Dict[Hashable, Array] = get_indices(self.agents.market_ids)
 
         # identify the largest number of products and agents in a market
         self._max_J = max(i.size for i in self._product_market_indices.values())

--- a/pyblp/economies/economy.py
+++ b/pyblp/economies/economy.py
@@ -75,9 +75,9 @@ class Economy(Container, StringRepresentation):
 
         # identify market indices
         s = pd.Series(self.products.market_ids.flatten())
-        self._product_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).groups.items()}
+        self._product_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).indices.items()}
         s = pd.Series(self.agents.market_ids.flatten())
-        self._agent_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).groups.items()}
+        self._agent_market_indices: Dict[Hashable, Array] = {k: v for k, v in s.groupby(s).indices.items()}
 
         # identify the largest number of products and agents in a market
         self._max_J = max(i.size for i in self._product_market_indices.values())

--- a/pyblp/utilities/basics.py
+++ b/pyblp/utilities/basics.py
@@ -295,6 +295,16 @@ def format_table(
     return "\n".join(lines)
 
 
+def get_indices(ids) -> Dict[Hashable, Array]:
+    flat = ids.flatten()
+    sort_indices = flat.argsort(kind='mergesort')
+    sorted_ids = flat[sort_indices]
+    changes = np.ones(flat.shape, np.bool)
+    changes[1:] = sorted_ids[1:] != sorted_ids[:-1]
+    reduce_indices = np.nonzero(changes)[0]
+    return dict(zip(sorted_ids[reduce_indices], np.split(sort_indices, reduce_indices)[1:]))
+
+
 class SolverStats(object):
     """Structured statistics returned by a generic numerical solver."""
 

--- a/pyblp/utilities/basics.py
+++ b/pyblp/utilities/basics.py
@@ -295,7 +295,19 @@ def format_table(
     return "\n".join(lines)
 
 
-def get_indices(ids) -> Dict[Hashable, Array]:
+def get_indices(ids: Array) -> Dict[Hashable, Array]:
+    """get_indices takes a one-dimensional array input and returns a
+    dictionary such that the keys are the unique values of the array
+    and the values are the indices where the key appears in the array.
+
+    Examples
+    --------
+
+    >>> ids = np.array([1, 2, 1, 2, 3, 3, 1, 2])
+    >>> get_indices(ids)
+    {1: array([0, 2, 6]), 2: array([1, 3, 7]), 3: array([4, 5])}
+    """
+
     flat = ids.flatten()
     sort_indices = flat.argsort(kind='mergesort')
     sorted_ids = flat[sort_indices]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.16.0
 patsy>=0.5.1
 scipy>=1.2.0
 sympy>=1.1.0
+pandas>=0.24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy>=1.16.0
 patsy>=0.5.1
 scipy>=1.2.0
 sympy>=1.1.0
-pandas>=0.24.2


### PR DESCRIPTION
With a large number of markets, a large number of observations, or both, identifying the market indices in pyblp/economies/economy.py lines 76-80 becomes prohibitively time-consuming. We found that using pandas.Series.groupby got rid of the bottleneck.

PS: I wonder if maybe you didn't want pandas as a dependency? I figured that it might be OK to add it since all the docs assume the user will have pandas. The speedup seems to warrant it.