### PR TITLE
Update construction.py

### DIFF
--- a/pyblp/construction.py
+++ b/pyblp/construction.py
@@ -414,7 +414,7 @@ def build_differentiation_instruments(
                         yield close
                     else:
                         for k2 in range(K):
-                            yield close * distances_mapping[k2]
+                            yield close * np.nan_to_num(distances_mapping[k2])
                 else:
                     raise ValueError("version must be 'local' or 'quadratic'.")
 


### PR DESCRIPTION
The output of build_differentiation_instruments with interact options will be empty. This will fix that problem.