### PR TITLE
Documentation: Clarify SQUAREM error handling

### DIFF
--- a/pyblp/configurations/iteration.py
+++ b/pyblp/configurations/iteration.py
@@ -26,8 +26,7 @@ class Iteration(StringRepresentation):
 
             - ``'squarem'`` - SQUAREM acceleration method of :ref:`references:Varadhan and Roland (2008)` and considered
               in the context of the BLP problem in :ref:`references:Reynaerts, Varadhan, and Nash (2012)`. This
-              implementation uses a first-order squared non-monotone extrapolation scheme. If there are any errors
-              during the acceleration step, it uses the last values for the next iteration of the algorithm.
+              implementation uses a first-order squared non-monotone extrapolation scheme.
 
             - ``'broyden1'`` - Use the :func:`scipy.optimize.root` Broyden's first Jacobian approximation method, known
               as Broyden's good method.


### PR DESCRIPTION
In the past, errors in the SQUAREM acceleration step were [reverted](https://github.com/jeffgortmaker/pyblp/blob/bad73f4404b1828fb69a0e9b7a9d25e681549f64/pyblp/configurations/iteration.py#L240); this is no longer the case [now](https://github.com/jeffgortmaker/pyblp/blob/ca745cb4f1279ed3e66b70a161f1ed9c007fd9c8/pyblp/configurations/iteration.py#L437). Updated docs.